### PR TITLE
Mudando padrão Mandíbula Horrenda

### DIFF
--- a/upAte99Remake/1campoDeAprendiz.event
+++ b/upAte99Remake/1campoDeAprendiz.event
@@ -69,6 +69,7 @@ automacro TalkSprakkiOutside {
 		do iconf 13041 0 0 0
 		do iconf 2393 0 0 0
 		do iconf 2301 0 0 0
+		do iconf 958 10 1 0 #mandibula
 		]
 		do talk $.NpcNearLastBinId
 	}


### PR DESCRIPTION
Ao fazer download do Openkore o padrão pra Mandibula é: 
958 0 0 1  

do iconf 958 10 1 0
E com isso antes de chamar a macro pra fazer a quest ele vende todas e é um item relativamente raro com taxas de drop de .5%
Isso faz com que ele demore muito para dropar e atrasa a quest de arruaceiro.


@rickreaper obrigado pela contribuição, vou pegar pra mim :smile: 